### PR TITLE
Add babel-cli as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "ReSys OÜ",
   "license": "ASL-2.0",
   "devDependencies": {
+    "babel-cli": "^6.14.0",
     "babel-core": "^6.6.0",
     "babel-eslint": "^6.0.0",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
Fixes the problem where when running `npm install` you get the error:

```
babel src --out-dir lib

sh: babel: command not found
```

This is because the `build:lib` script uses the `babel` command, which has been extracted to `babel-cli`.
